### PR TITLE
Add source for icon export helper Figma plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/figma-plugins/icon-export-helper/node_modules

--- a/figma-plugins/icon-export-helper/README.md
+++ b/figma-plugins/icon-export-helper/README.md
@@ -1,0 +1,6 @@
+
+# Bitcoin icon set export helper
+
+This folder contains the source code for a Figma plugin that helps exporting the icons from Figma in the desired formats. Working with visual assets in a design tool is very different than in development. This is a single-purpose plugin and is only relevant to anyone who wants to update the PNGs and SVGs in this repo from the source Figma file.
+
+In your Terminal, run `npm install` in this folder to download required dependencies. Then run `npm build` to compile the plugin. In Figma, add a new plugin via the `Link existing plugin`option. Go to the `icons` page and run the plugin. It creates a new page with all icons ready to be exported.

--- a/figma-plugins/icon-export-helper/code.js
+++ b/figma-plugins/icon-export-helper/code.js
@@ -4,57 +4,76 @@ page.name = "Icons for export";
 figma.root.appendChild(page);
 // Get all nodes that are components and begin with "Icon/"
 const nodes = figma.currentPage.findAll(node => node.name.indexOf('Icon/') === 0 && node.type == 'COMPONENT_SET');
-// console.log('nodes', nodes);
 const newNodes = [];
 let x = 0;
 let y = 0;
 // Create instance of each component and variant
 for (const node of nodes) {
-    // console.log('node', node);
+    // Only use components with variants.
     if (node.type === 'COMPONENT_SET') {
+        // Loop all component variants.
         for (const nodeVariant of node.children) {
             if (nodeVariant.type === 'COMPONENT') {
-                // console.log('nodeVariant', nodeVariant)
-                const nodeInstance = nodeVariant.createInstance();
-                // console.log('nodeInstance', nodeInstance)
                 if (nodeVariant.type === 'COMPONENT') {
-                    // console.log('mainComponent', nodeInstance.mainComponent.name)
-                    // console.log('masterComponent', nodeInstance.masterComponent)
-                    // for(const testo in nodeInstance.mainComponent) {
-                    // 	console.log(testo, nodeInstance.mainComponent[testo])
-                    // }
-                    nodeInstance.x += x * 40;
-                    nodeInstance.y += y * 40;
-                    let newName = node.name.substr(5).toLowerCase().replace(' ', '_');
-                    const variantNameBits = nodeInstance.mainComponent.name.split(', ');
+                    let exportIcon = false;
+                    // Variant settings are stored in the instance name.
+                    // Use them to figure out whether to export and into which folder.
+                    // "Style=Filled, Size=Big"
+                    const variantNameBits = nodeVariant.name.split(', ');
+                    let subFolder = '';
                     for (const bit of variantNameBits) {
-                        newName += '-' + bit.split('=')[1];
-                    }
-                    newName = newName.toLowerCase().replace(' ', '-');
-                    nodeInstance.name = newName;
-                    nodeInstance.exportSettings = [
-                        {
-                            contentsOnly: true,
-                            format: 'SVG',
-                            suffix: '',
-                            svgIdAttribute: false,
-                            svgOutlineText: true,
-                            svgSimplifyStroke: true
+                        const subBits = bit.split('=');
+                        switch (subBits[0]) {
+                            case 'Style':
+                                // Use the style name as folder name
+                                subFolder = subBits[1] + '/';
+                                break;
+                            case 'Size':
+                                // Only export Medium sizes for now
+                                exportIcon = subBits[1] == 'Medium';
+                                break;
                         }
-                    ];
-                    page.appendChild(nodeInstance);
-                    newNodes.push(nodeInstance);
-                    x++;
-                    if (x >= 10) {
-                        x = 0;
-                        y += 1;
+                    }
+                    if (exportIcon === true) {
+                        const nodeInstance = nodeVariant.createInstance();
+                        // Position nicely, assuming a 40x40 grid.
+                        nodeInstance.x += x * 40;
+                        nodeInstance.y += y * 40;
+                        // Finalize name.
+                        // "Icon/Bitcoin circle" with variant "Style=Outline" becomes
+                        // "outline/bitcoin-circle"
+                        let newName = subFolder + node.name.split('/')[1];
+                        newName = newName.toLowerCase().replace(' ', '-');
+                        nodeInstance.name = newName;
+                        nodeInstance.exportSettings = [
+                            {
+                                contentsOnly: true,
+                                format: 'SVG',
+                                suffix: '',
+                                svgIdAttribute: false,
+                                svgOutlineText: true,
+                                svgSimplifyStroke: true
+                            }
+                        ];
+                        // Add instance to our new page.
+                        page.appendChild(nodeInstance);
+                        // Keep track of instances for selection.
+                        newNodes.push(nodeInstance);
+                        x++;
+                        // Reset the row every 10 icons
+                        if (x >= 10) {
+                            x = 0;
+                            y += 1;
+                        }
                     }
                 }
             }
         }
     }
 }
+// Select our new instances for easy export.
 page.selection = newNodes;
+// Go to our new page.
 figma.currentPage = page;
 // Make sure to close the plugin when you're done. Otherwise the plugin will
 // keep running, which shows the cancel button at the bottom of the screen.

--- a/figma-plugins/icon-export-helper/code.js
+++ b/figma-plugins/icon-export-helper/code.js
@@ -1,0 +1,61 @@
+// Create new page
+const page = figma.createPage();
+page.name = "Icons for export";
+figma.root.appendChild(page);
+// Get all nodes that are components and begin with "Icon/"
+const nodes = figma.currentPage.findAll(node => node.name.indexOf('Icon/') === 0 && node.type == 'COMPONENT_SET');
+// console.log('nodes', nodes);
+const newNodes = [];
+let x = 0;
+let y = 0;
+// Create instance of each component and variant
+for (const node of nodes) {
+    // console.log('node', node);
+    if (node.type === 'COMPONENT_SET') {
+        for (const nodeVariant of node.children) {
+            if (nodeVariant.type === 'COMPONENT') {
+                // console.log('nodeVariant', nodeVariant)
+                const nodeInstance = nodeVariant.createInstance();
+                // console.log('nodeInstance', nodeInstance)
+                if (nodeVariant.type === 'COMPONENT') {
+                    // console.log('mainComponent', nodeInstance.mainComponent.name)
+                    // console.log('masterComponent', nodeInstance.masterComponent)
+                    // for(const testo in nodeInstance.mainComponent) {
+                    // 	console.log(testo, nodeInstance.mainComponent[testo])
+                    // }
+                    nodeInstance.x += x * 40;
+                    nodeInstance.y += y * 40;
+                    let newName = node.name.substr(5).toLowerCase().replace(' ', '_');
+                    const variantNameBits = nodeInstance.mainComponent.name.split(', ');
+                    for (const bit of variantNameBits) {
+                        newName += '-' + bit.split('=')[1];
+                    }
+                    newName = newName.toLowerCase().replace(' ', '-');
+                    nodeInstance.name = newName;
+                    nodeInstance.exportSettings = [
+                        {
+                            contentsOnly: true,
+                            format: 'SVG',
+                            suffix: '',
+                            svgIdAttribute: false,
+                            svgOutlineText: true,
+                            svgSimplifyStroke: true
+                        }
+                    ];
+                    page.appendChild(nodeInstance);
+                    newNodes.push(nodeInstance);
+                    x++;
+                    if (x >= 10) {
+                        x = 0;
+                        y += 1;
+                    }
+                }
+            }
+        }
+    }
+}
+page.selection = newNodes;
+figma.currentPage = page;
+// Make sure to close the plugin when you're done. Otherwise the plugin will
+// keep running, which shows the cancel button at the bottom of the screen.
+figma.closePlugin();

--- a/figma-plugins/icon-export-helper/code.ts
+++ b/figma-plugins/icon-export-helper/code.ts
@@ -1,0 +1,71 @@
+// Create new page
+
+const page = figma.createPage()
+page.name = "Icons for export"
+
+figma.root.appendChild(page);
+
+// Get all nodes that are components and begin with "Icon/"
+const nodes = figma.currentPage.findAll(node => node.name.indexOf('Icon/') === 0 && node.type == 'COMPONENT_SET')
+
+// console.log('nodes', nodes);
+const newNodes = []
+
+let x = 0
+let y = 0
+
+// Create instance of each component and variant
+for (const node of nodes) {
+	if(node.type === 'COMPONENT_SET') {
+
+		for(const nodeVariant of node.children) {
+			if(nodeVariant.type === 'COMPONENT') {
+				const nodeInstance = nodeVariant.createInstance()
+
+				if(nodeVariant.type === 'COMPONENT') {
+					nodeInstance.x += x * 40
+					nodeInstance.y += y * 40
+
+					let newName = node.name.substr(5).toLowerCase().replace(' ', '_')
+
+					const variantNameBits = nodeInstance.mainComponent.name.split(', ')
+					for(const bit of variantNameBits) {
+						newName += '-' + bit.split('=')[1]
+					}
+
+					newName = newName.toLowerCase().replace(' ', '-')
+					nodeInstance.name = newName
+
+					nodeInstance.exportSettings = [
+						{
+							contentsOnly: true,
+							format: 'SVG',
+							suffix: '',
+							svgIdAttribute: false,
+							svgOutlineText: true,
+							svgSimplifyStroke: true
+						}
+					]
+
+					page.appendChild(nodeInstance)
+
+					newNodes.push(nodeInstance)
+
+					x++
+
+					if(x >= 10) {
+						x = 0
+						y += 1
+					}
+				}
+			}
+		}
+	}
+}
+
+page.selection = newNodes
+figma.currentPage = page
+
+// Make sure to close the plugin when you're done. Otherwise the plugin will
+// keep running, which shows the cancel button at the bottom of the screen.
+figma.closePlugin()

--- a/figma-plugins/icon-export-helper/code.ts
+++ b/figma-plugins/icon-export-helper/code.ts
@@ -1,5 +1,4 @@
 // Create new page
-
 const page = figma.createPage()
 page.name = "Icons for export"
 
@@ -8,7 +7,6 @@ figma.root.appendChild(page);
 // Get all nodes that are components and begin with "Icon/"
 const nodes = figma.currentPage.findAll(node => node.name.indexOf('Icon/') === 0 && node.type == 'COMPONENT_SET')
 
-// console.log('nodes', nodes);
 const newNodes = []
 
 let x = 0
@@ -16,46 +14,73 @@ let y = 0
 
 // Create instance of each component and variant
 for (const node of nodes) {
+	// Only use components with variants.
 	if(node.type === 'COMPONENT_SET') {
 
+		// Loop all component variants.
 		for(const nodeVariant of node.children) {
 			if(nodeVariant.type === 'COMPONENT') {
-				const nodeInstance = nodeVariant.createInstance()
-
 				if(nodeVariant.type === 'COMPONENT') {
-					nodeInstance.x += x * 40
-					nodeInstance.y += y * 40
+					let exportIcon = false
 
-					let newName = node.name.substr(5).toLowerCase().replace(' ', '_')
-
-					const variantNameBits = nodeInstance.mainComponent.name.split(', ')
+					// Variant settings are stored in the instance name.
+					// Use them to figure out whether to export and into which folder.
+					// "Style=Filled, Size=Big"
+					const variantNameBits = nodeVariant.name.split(', ')
+					let subFolder = ''
 					for(const bit of variantNameBits) {
-						newName += '-' + bit.split('=')[1]
+						const subBits = bit.split('=')
+
+						switch(subBits[0]) {
+							case 'Style':
+								// Use the style name as folder name
+								subFolder = subBits[1] + '/'
+								break;
+							case 'Size':
+								// Only export Medium sizes for now
+								exportIcon = subBits[1] == 'Medium'
+								break;
+						}
 					}
 
-					newName = newName.toLowerCase().replace(' ', '-')
-					nodeInstance.name = newName
+					if(exportIcon === true) {
+						const nodeInstance = nodeVariant.createInstance()
 
-					nodeInstance.exportSettings = [
-						{
-							contentsOnly: true,
-							format: 'SVG',
-							suffix: '',
-							svgIdAttribute: false,
-							svgOutlineText: true,
-							svgSimplifyStroke: true
+						// Position nicely, assuming a 40x40 grid.
+						nodeInstance.x += x * 40
+						nodeInstance.y += y * 40
+
+						// Finalize name.
+						// "Icon/Bitcoin circle" with variant "Style=Outline" becomes
+						// "outline/bitcoin-circle"
+						let newName = subFolder + node.name.split('/')[1]
+						newName = newName.toLowerCase().replace(' ', '-')
+						nodeInstance.name = newName
+
+						nodeInstance.exportSettings = [
+							{
+								contentsOnly: true,
+								format: 'SVG',
+								suffix: '',
+								svgIdAttribute: false,
+								svgOutlineText: true,
+								svgSimplifyStroke: true
+							}
+						]
+
+						// Add instance to our new page.
+						page.appendChild(nodeInstance)
+
+						// Keep track of instances for selection.
+						newNodes.push(nodeInstance)
+
+						x++
+
+						// Reset the row every 10 icons
+						if(x >= 10) {
+							x = 0
+							y += 1
 						}
-					]
-
-					page.appendChild(nodeInstance)
-
-					newNodes.push(nodeInstance)
-
-					x++
-
-					if(x >= 10) {
-						x = 0
-						y += 1
 					}
 				}
 			}
@@ -63,7 +88,10 @@ for (const node of nodes) {
 	}
 }
 
+// Select our new instances for easy export.
 page.selection = newNodes
+
+// Go to our new page.
 figma.currentPage = page
 
 // Make sure to close the plugin when you're done. Otherwise the plugin will

--- a/figma-plugins/icon-export-helper/manifest.json
+++ b/figma-plugins/icon-export-helper/manifest.json
@@ -1,0 +1,6 @@
+{
+  "name": "Bitcoin icon set export helper",
+  "id": "948951594643804843",
+  "api": "1.0.0",
+  "main": "code.js"
+}

--- a/figma-plugins/icon-export-helper/package-lock.json
+++ b/figma-plugins/icon-export-helper/package-lock.json
@@ -1,0 +1,30 @@
+{
+  "name": "Bitcoin icon set export helper",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "Bitcoin icon set export helper",
+      "version": "1.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@figma/plugin-typings": "^1.19.2"
+      }
+    },
+    "node_modules/@figma/plugin-typings": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@figma/plugin-typings/-/plugin-typings-1.19.2.tgz",
+      "integrity": "sha512-FjZpc2dA4kRsnmgABcniXyRosQFS6uOqi/WhTyuc/Fm08lV5eE1aP0OwkTNCJY3DA5qXkYGBrjzyXS+OwRI3aw==",
+      "dev": true
+    }
+  },
+  "dependencies": {
+    "@figma/plugin-typings": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@figma/plugin-typings/-/plugin-typings-1.19.2.tgz",
+      "integrity": "sha512-FjZpc2dA4kRsnmgABcniXyRosQFS6uOqi/WhTyuc/Fm08lV5eE1aP0OwkTNCJY3DA5qXkYGBrjzyXS+OwRI3aw==",
+      "dev": true
+    }
+  }
+}

--- a/figma-plugins/icon-export-helper/package.json
+++ b/figma-plugins/icon-export-helper/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "Bitcoin icon set export helper",
+  "version": "1.0.0",
+  "description": "Simplifies export of production assets from the Bitcoin icon set Figma file.",
+  "main": "code.js",
+  "scripts": {
+    "build": "tsc -p tsconfig.json"
+  },
+  "author": "Christoph Ono",
+  "license": "MIT",
+  "devDependencies": {
+    "@figma/plugin-typings": "^1.19.2"
+  }
+}

--- a/figma-plugins/icon-export-helper/tsconfig.json
+++ b/figma-plugins/icon-export-helper/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "target": "es6",
+    "typeRoots": [
+      "./node_modules/@types",
+      "./node_modules/@figma"
+    ]
+  }
+}


### PR DESCRIPTION
This plugin makes it super easy to re-export icons from Figma to this repo. Just go to the icons page, run the plugin and click export. No manual renaming, adjusting export settings, etc.